### PR TITLE
Make .tbl argument explicit in suffix versions

### DIFF
--- a/R/rap.R
+++ b/R/rap.R
@@ -224,27 +224,27 @@ print.rap_lamdda <- function(x, ...) {
 
 #' @rdname rap
 #' @export
-wap_dbl <- function(...) wap(..., .ptype = double())
+wap_dbl <- function(.tbl, ...) wap(.tbl, ..., .ptype = double())
 
 #' @rdname rap
 #' @export
-wap_lgl <- function(...) wap(..., .ptype = logical())
+wap_lgl <- function(.tbl, ...) wap(.tbl, ..., .ptype = logical())
 
 #' @rdname rap
 #' @export
-wap_int <- function(...) wap(..., .ptype = integer())
+wap_int <- function(.tbl, ...) wap(.tbl, ..., .ptype = integer())
 
 #' @rdname rap
 #' @export
-wap_chr <- function(...) wap(..., .ptype = character())
+wap_chr <- function(.tbl, ...) wap(.tbl, ..., .ptype = character())
 
 #' @rdname rap
 #' @export
-wap_raw <- function(...) wap(..., .ptype = raw())
+wap_raw <- function(.tbl, ...) wap(.tbl, ..., .ptype = raw())
 
 #' @rdname rap
 #' @export
-wap_dfr <- function(...) wap(..., .ptype = data.frame())
+wap_dfr <- function(.tbl, ...) wap(.tbl, ..., .ptype = data.frame())
 
 #' @rdname rap
 #' @export
@@ -261,24 +261,24 @@ rap <- function(.tbl, ..., .ptype = list()) {
 
 #' @rdname rap
 #' @export
-rap_dbl <- function(...) rap(..., .ptype = double())
+rap_dbl <- function(.tbl, ...) rap(.tbl, ..., .ptype = double())
 
 #' @rdname rap
 #' @export
-rap_lgl <- function(...) rap(..., .ptype = logical())
+rap_lgl <- function(.tbl, ...) rap(.tbl, ..., .ptype = logical())
 
 #' @rdname rap
 #' @export
-rap_int <- function(...) rap(..., .ptype = integer())
+rap_int <- function(.tbl, ...) rap(.tbl, ..., .ptype = integer())
 
 #' @rdname rap
 #' @export
-rap_chr <- function(...) rap(..., .ptype = character())
+rap_chr <- function(.tbl, ...) rap(.tbl, ..., .ptype = character())
 
 #' @rdname rap
 #' @export
-rap_raw <- function(...) rap(..., .ptype = raw())
+rap_raw <- function(.tbl, ...) rap(.tbl, ..., .ptype = raw())
 
 #' @rdname rap
 #' @export
-rap_dfr <- function(...) rap(..., .ptype = data.frame())
+rap_dfr <- function(.tbl, ...) rap(.tbl, ..., .ptype = data.frame())

--- a/man/rap.Rd
+++ b/man/rap.Rd
@@ -25,31 +25,31 @@ nap(.tbl, ...)
 
 lap(.tbl, ..., .ptype = list())
 
-wap_dbl(...)
+wap_dbl(.tbl, ...)
 
-wap_lgl(...)
+wap_lgl(.tbl, ...)
 
-wap_int(...)
+wap_int(.tbl, ...)
 
-wap_chr(...)
+wap_chr(.tbl, ...)
 
-wap_raw(...)
+wap_raw(.tbl, ...)
 
-wap_dfr(...)
+wap_dfr(.tbl, ...)
 
 rap(.tbl, ..., .ptype = list())
 
-rap_dbl(...)
+rap_dbl(.tbl, ...)
 
-rap_lgl(...)
+rap_lgl(.tbl, ...)
 
-rap_int(...)
+rap_int(.tbl, ...)
 
-rap_chr(...)
+rap_chr(.tbl, ...)
 
-rap_raw(...)
+rap_raw(.tbl, ...)
 
-rap_dfr(...)
+rap_dfr(.tbl, ...)
 }
 \arguments{
 \item{.tbl}{A data frame}


### PR DESCRIPTION
The suffixed versions should all have a `.tbl` arg, correct?