### PR TITLE
renamed tbl column names for clarity

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Version: 0.0.0.9000
 Authors@R: c(
       person("Romain", "François", email = "romain@purrple.cat", role = c("aut", "cre")), 
       person("Davis", "Vaughan", role = c("ctb", "rev")), 
-      person(“Suthira”, “Owlarn”, role = c("ctb", "rev")), 
+      person("Suthira", "Owlarn", role = c("ctb", "rev")), 
       person("Thomas Lin", "Pedersen", role = c("art"))
     )
 Description: rowwise operations on a data frame.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,6 +4,7 @@ Version: 0.0.0.9000
 Authors@R: c(
       person("Romain", "François", email = "romain@purrple.cat", role = c("aut", "cre")), 
       person("Davis", "Vaughan", role = c("ctb", "rev")), 
+      person(“Suthira”, “Owlarn”, role = c("ctb", "rev")), 
       person("Thomas Lin", "Pedersen", role = c("art"))
     )
 Description: rowwise operations on a data frame.

--- a/README.Rmd
+++ b/README.Rmd
@@ -50,11 +50,11 @@ which stand for a single element of the associated vector, in the `[[` sense.
 library(tidyverse)
 library(rap)
 
-tbl <- tibble(cyl = c(4, 6, 8), mpg = c(30, 25, 20)) 
+tbl <- tibble(cyl_threshold = c(4, 6, 8), mpg_threshold = c(30, 25, 20)) 
 tbl
 
 tbl %>% 
-  rap(x = ~filter(mtcars, cyl == !!cyl, mpg < !!mpg) )
+  rap(x = ~filter(mtcars, cyl == !!cyl_threshold, mpg < !!mpg_threshold))
 ```
 
 If the lhs of the formula is empty, `rap()` adds a list column. Otherwise the lhs 
@@ -63,7 +63,7 @@ can be used to specify the type:
 ```{r}
 tbl %>% 
   rap(
-    x =           ~ filter(mtcars, cyl == !!cyl, mpg < !!mpg), 
+    x =           ~ filter(mtcars, cyl == !!cyl_threshold, mpg < !!mpg_threshold), 
     n = integer() ~ nrow(x)
   )
 ```
@@ -75,7 +75,7 @@ which has equivalent with `pmap`:
 tbl %>%
   mutate(
     x = pmap(
-      .l = list(cyl, mpg),
+      .l = list(cyl_threshold, mpg_threshold),
       function(cc, mm) filter(mtcars, cyl == cc, mpg < mm)
     ), 
     n = map_int(x, nrow)
@@ -104,7 +104,7 @@ starwars %>%
 
 # Specify type as data.frame() row binds them
 starwars %>% 
-  wap( data.frame() ~ data.frame(vehicles = length(vehicles), starships = length(starships)))
+  wap(data.frame() ~ data.frame(vehicles = length(vehicles), starships = length(starships)))
 ```
 
 
@@ -114,15 +114,12 @@ starwars %>%
 you control what goes in the nested column. `Z` is `N` but `r emo::ji("arrow_heading_down")`. 
 
 ```{r}
-tbl <- tibble(cyl = c(4, 6, 8), mpg = c(30, 25, 20)) 
+tbl <- tibble(cyl_threshold = c(4, 6, 8), mpg_threshold = c(30, 25, 20)) 
 tbl %>%
-  zest_join(mtcars, data = ~cyl == !!cyl & mpg < !!mpg)
+  zest_join(mtcars, data = ~cyl == !!cyl_threshold & mpg < !!mpg_threshold)
 ```
 
 In the rhs of the formula : 
 
   - `cyl` and `mpg` refer to columns of `mtcars`
-  - `!!cyl` and `!!mpg` refer to the current value from `tbl` 
-
-
-
+  - `!!cyl_threshold` and `!!mpg_threshold` refer to the current value from `tbl` 

--- a/README.Rmd
+++ b/README.Rmd
@@ -54,7 +54,7 @@ tbl <- tibble(cyl_threshold = c(4, 6, 8), mpg_threshold = c(30, 25, 20))
 tbl
 
 tbl %>% 
-  rap(x = ~filter(mtcars, cyl == !!cyl_threshold, mpg < !!mpg_threshold))
+  rap(x = ~filter(mtcars, cyl == cyl_threshold, mpg < mpg_threshold))
 ```
 
 If the lhs of the formula is empty, `rap()` adds a list column. Otherwise the lhs 
@@ -63,7 +63,7 @@ can be used to specify the type:
 ```{r}
 tbl %>% 
   rap(
-    x =           ~ filter(mtcars, cyl == !!cyl_threshold, mpg < !!mpg_threshold), 
+    x =           ~ filter(mtcars, cyl == cyl_threshold, mpg < mpg_threshold), 
     n = integer() ~ nrow(x)
   )
 ```
@@ -122,4 +122,4 @@ tbl %>%
 In the rhs of the formula : 
 
   - `cyl` and `mpg` refer to columns of `mtcars`
-  - `!!cyl_threshold` and `!!mpg_threshold` refer to the current value from `tbl` 
+  - `cyl_threshold` and `mpg_threshold` refer to the current value from `tbl` because these columns don't exist in mtcars. If you wanted to refer to columns that are present both in mtcars and tbl you would have to unquote the columns in tbl with the unquoting operator, e.g. !!cyl

--- a/README.Rmd
+++ b/README.Rmd
@@ -116,7 +116,7 @@ you control what goes in the nested column. `Z` is `N` but `r emo::ji("arrow_hea
 ```{r}
 tbl <- tibble(cyl_threshold = c(4, 6, 8), mpg_threshold = c(30, 25, 20)) 
 tbl %>%
-  zest_join(mtcars, data = ~cyl == !!cyl_threshold & mpg < !!mpg_threshold)
+  zest_join(mtcars, data = ~cyl == cyl_threshold & mpg < mpg_threshold)
 ```
 
 In the rhs of the formula : 

--- a/README.md
+++ b/README.md
@@ -49,23 +49,23 @@ library(tidyverse)
 #> ✖ dplyr::lag()    masks stats::lag()
 library(rap)
 
-tbl <- tibble(cyl = c(4, 6, 8), mpg = c(30, 25, 20)) 
+tbl <- tibble(cyl_threshold = c(4, 6, 8), mpg_threshold = c(30, 25, 20)) 
 tbl
 #> # A tibble: 3 x 2
-#>     cyl   mpg
-#>   <dbl> <dbl>
-#> 1     4    30
-#> 2     6    25
-#> 3     8    20
+#>   cyl_threshold mpg_threshold
+#>           <dbl>         <dbl>
+#> 1             4            30
+#> 2             6            25
+#> 3             8            20
 
 tbl %>% 
-  rap(x = ~filter(mtcars, cyl == !!cyl, mpg < !!mpg) )
+  rap(x = ~filter(mtcars, cyl == !!cyl_threshold, mpg < !!mpg_threshold))
 #> # A tibble: 3 x 3
-#>     cyl   mpg x                     
-#>   <dbl> <dbl> <list>                
-#> 1     4    30 <data.frame [7 × 11]> 
-#> 2     6    25 <data.frame [7 × 11]> 
-#> 3     8    20 <data.frame [14 × 11]>
+#>   cyl_threshold mpg_threshold x                     
+#>           <dbl>         <dbl> <list>                
+#> 1             4            30 <data.frame [7 × 11]> 
+#> 2             6            25 <data.frame [7 × 11]> 
+#> 3             8            20 <data.frame [14 × 11]>
 ```
 
 If the lhs of the formula is empty, `rap()` adds a list column.
@@ -74,15 +74,15 @@ Otherwise the lhs can be used to specify the type:
 ``` r
 tbl %>% 
   rap(
-    x =           ~ filter(mtcars, cyl == !!cyl, mpg < !!mpg), 
+    x =           ~ filter(mtcars, cyl == !!cyl_threshold, mpg < !!mpg_threshold), 
     n = integer() ~ nrow(x)
   )
 #> # A tibble: 3 x 4
-#>     cyl   mpg x                          n
-#>   <dbl> <dbl> <list>                 <int>
-#> 1     4    30 <data.frame [7 × 11]>      7
-#> 2     6    25 <data.frame [7 × 11]>      7
-#> 3     8    20 <data.frame [14 × 11]>    14
+#>   cyl_threshold mpg_threshold x                          n
+#>           <dbl>         <dbl> <list>                 <int>
+#> 1             4            30 <data.frame [7 × 11]>      7
+#> 2             6            25 <data.frame [7 × 11]>      7
+#> 3             8            20 <data.frame [14 × 11]>    14
 ```
 
 this example is based on this
@@ -93,17 +93,17 @@ equivalent with `pmap`:
 tbl %>%
   mutate(
     x = pmap(
-      .l = list(cyl, mpg),
+      .l = list(cyl_threshold, mpg_threshold),
       function(cc, mm) filter(mtcars, cyl == cc, mpg < mm)
     ), 
     n = map_int(x, nrow)
   )
 #> # A tibble: 3 x 4
-#>     cyl   mpg x                          n
-#>   <dbl> <dbl> <list>                 <int>
-#> 1     4    30 <data.frame [7 × 11]>      7
-#> 2     6    25 <data.frame [7 × 11]>      7
-#> 3     8    20 <data.frame [14 × 11]>    14
+#>   cyl_threshold mpg_threshold x                          n
+#>           <dbl>         <dbl> <list>                 <int>
+#> 1             4            30 <data.frame [7 × 11]>      7
+#> 2             6            25 <data.frame [7 × 11]>      7
+#> 3             8            20 <data.frame [14 × 11]>    14
 ```
 
 ## wap
@@ -185,18 +185,18 @@ starwars %>%
 goes in the nested column. `Z` is `N` but ⤵️.
 
 ``` r
-tbl <- tibble(cyl = c(4, 6, 8), mpg = c(30, 25, 20)) 
+tbl <- tibble(cyl_threshold = c(4, 6, 8), mpg_threshold = c(30, 25, 20)) 
 tbl %>%
-  zest_join(mtcars, data = ~cyl == !!cyl & mpg < !!mpg)
+  zest_join(mtcars, data = ~cyl == !!cyl_threshold & mpg < !!mpg_threshold)
 #> # A tibble: 3 x 3
-#>     cyl   mpg data                  
-#>   <dbl> <dbl> <list>                
-#> 1     4    30 <data.frame [7 × 11]> 
-#> 2     6    25 <data.frame [7 × 11]> 
-#> 3     8    20 <data.frame [14 × 11]>
+#>   cyl_threshold mpg_threshold data                  
+#>           <dbl>         <dbl> <list>                
+#> 1             4            30 <data.frame [7 × 11]> 
+#> 2             6            25 <data.frame [7 × 11]> 
+#> 3             8            20 <data.frame [14 × 11]>
 ```
 
 In the rhs of the formula :
 
   - `cyl` and `mpg` refer to columns of `mtcars`
-  - `!!cyl` and `!!mpg` refer to the current value from `tbl`
+  - `!!cyl_threshold` and `!!mpg_threshold` refer to the current value from `tbl`

--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
+rap <img src="man/figures/logo.png" align="right" />
+====================================================
 
-# rap <img src="man/figures/logo.png" align="right" />
-
-[![Lifecycle
-Status](https://img.shields.io/badge/lifecycle-experimental-blue.svg)](https://www.tidyverse.org/lifecycle/)
-[![Travis build
-status](https://travis-ci.org/romainfrancois/rap.svg?branch=master)](https://travis-ci.org/romainfrancois/rap)
+[![Lifecycle Status](https://img.shields.io/badge/lifecycle-experimental-blue.svg)](https://www.tidyverse.org/lifecycle/) [![Travis build status](https://travis-ci.org/romainfrancois/rap.svg?branch=master)](https://travis-ci.org/romainfrancois/rap)
 
 ![](https://media.giphy.com/media/l41Yy7rv1mVZNQCT6/giphy.gif)
 
 Experimenting with yet another way to do rowwise operations.
 
-## Installation
+Installation
+------------
 
 You can install `rap` from gitub
 
@@ -21,30 +19,29 @@ You can install `rap` from gitub
 devtools::install_github("romainfrancois/rap")
 ```
 
-## Why
+Why
+---
 
 This offers `rap()` as an alternative to some versions of:
 
-  - `rowwise()` + `do()`
-  - `mutate()` + `pmap()`
-  - maybe `purrrlyr` ?
-  - probably other approaches
+-   `rowwise()` + `do()`
+-   `mutate()` + `pmap()`
+-   maybe `purrrlyr` ?
+-   probably other approaches
 
-`rap()` works with lambdas supplied as formulas, similar to
-`purrr::map()` but instead of `.x`, `.y`, `..1`, `..2`, …the lambda can
-use the column names, which stand for a single element of the associated
-vector, in the `[[` sense.
+`rap()` works with lambdas supplied as formulas, similar to `purrr::map()` but instead of `.x`, `.y`, `..1`, `..2`, ...the lambda can use the column names, which stand for a single element of the associated vector, in the `[[` sense.
 
-## rap
+rap
+---
 
 ``` r
 library(tidyverse)
-#> ── Attaching packages ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── tidyverse 1.2.1 ──
-#> ✔ ggplot2 3.0.0.9000      ✔ purrr   0.2.5.9000 
-#> ✔ tibble  1.4.99.9005     ✔ dplyr   0.7.99.9000
-#> ✔ tidyr   0.8.2.9000      ✔ stringr 1.3.1      
-#> ✔ readr   1.1.1           ✔ forcats 0.3.0.9000
-#> ── Conflicts ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── tidyverse_conflicts() ──
+#> ── Attaching packages ──────────────────── tidyverse 1.2.1 ──
+#> ✔ ggplot2 3.1.0           ✔ purrr   0.2.5.9000 
+#> ✔ tibble  1.4.99.9006     ✔ dplyr   0.7.8      
+#> ✔ tidyr   0.8.1           ✔ stringr 1.3.1      
+#> ✔ readr   1.1.1           ✔ forcats 0.3.0
+#> ── Conflicts ─────────────────────── tidyverse_conflicts() ──
 #> ✖ dplyr::filter() masks stats::filter()
 #> ✖ dplyr::lag()    masks stats::lag()
 library(rap)
@@ -59,7 +56,7 @@ tbl
 #> 3             8            20
 
 tbl %>% 
-  rap(x = ~filter(mtcars, cyl == !!cyl_threshold, mpg < !!mpg_threshold))
+  rap(x = ~filter(mtcars, cyl == cyl_threshold, mpg < mpg_threshold))
 #> # A tibble: 3 x 3
 #>   cyl_threshold mpg_threshold x                     
 #>           <dbl>         <dbl> <list>                
@@ -68,13 +65,12 @@ tbl %>%
 #> 3             8            20 <data.frame [14 × 11]>
 ```
 
-If the lhs of the formula is empty, `rap()` adds a list column.
-Otherwise the lhs can be used to specify the type:
+If the lhs of the formula is empty, `rap()` adds a list column. Otherwise the lhs can be used to specify the type:
 
 ``` r
 tbl %>% 
   rap(
-    x =           ~ filter(mtcars, cyl == !!cyl_threshold, mpg < !!mpg_threshold), 
+    x =           ~ filter(mtcars, cyl == cyl_threshold, mpg < mpg_threshold), 
     n = integer() ~ nrow(x)
   )
 #> # A tibble: 3 x 4
@@ -85,9 +81,7 @@ tbl %>%
 #> 3             8            20 <data.frame [14 × 11]>    14
 ```
 
-this example is based on this
-[issue](https://github.com/tidyverse/purrr/issues/280), which has
-equivalent with `pmap`:
+this example is based on this [issue](https://github.com/tidyverse/purrr/issues/280), which has equivalent with `pmap`:
 
 ``` r
 tbl %>%
@@ -106,7 +100,8 @@ tbl %>%
 #> 3             8            20 <data.frame [14 × 11]>    14
 ```
 
-## wap
+wap
+---
 
 ``` r
 library(dplyr)
@@ -169,7 +164,7 @@ starwars %>%
 
 # Specify type as data.frame() row binds them
 starwars %>% 
-  wap( data.frame() ~ data.frame(vehicles = length(vehicles), starships = length(starships)))
+  wap(data.frame() ~ data.frame(vehicles = length(vehicles), starships = length(starships)))
 #>   vehicles starships
 #> 1        2         2
 #> 2        0         0
@@ -179,10 +174,10 @@ starwars %>%
 #> 6        0         0
 ```
 
-## zest\_join
+zest\_join
+----------
 
-🍋 `zest_join()` is similar to `dplyr::nest_join()` but you control what
-goes in the nested column. `Z` is `N` but ⤵️.
+🍋 `zest_join()` is similar to `dplyr::nest_join()` but you control what goes in the nested column. `Z` is `N` but ⤵️.
 
 ``` r
 tbl <- tibble(cyl_threshold = c(4, 6, 8), mpg_threshold = c(30, 25, 20)) 
@@ -198,5 +193,5 @@ tbl %>%
 
 In the rhs of the formula :
 
-  - `cyl` and `mpg` refer to columns of `mtcars`
-  - `!!cyl_threshold` and `!!mpg_threshold` refer to the current value from `tbl`
+-   `cyl` and `mpg` refer to columns of `mtcars`
+-   `cyl_threshold` and `mpg_threshold` refer to the current value from `tbl` because these columns don't exist in mtcars. If you wanted to refer to columns that are present both in mtcars and tbl you would have to unquote the columns in tbl with the unquoting operator, e.g. !!cyl


### PR DESCRIPTION
- changed tbl column names from "cyl" and "mpg" to "cyl_threshold" and "mpg_threshold" so it's maybe (hopefully) more obvious to someone who's never heard of tidy eval what the example functions do
note: just an idea from a newbie's perspective; please let me know if I should change it or if you have reservations! :)

- removed some spaces that were likely typos