### PR TITLE
Feature/mini model example

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
     vctrs,
     zeallot,
     magrittr
+Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1
 Remotes: 
     tidyverse/dplyr, 

--- a/R/rap.R
+++ b/R/rap.R
@@ -179,6 +179,15 @@ prepare_wap <- function(.tbl, .f, check = TRUE) {
 #'      n = integer() ~ nrow(x)
 #'   )
 #'
+#' # rap is especially useful for iterating
+#' # over multiple models
+#' starwars %>%
+#'   nest_by(gender) %>%
+#'   rap(
+#'     model = ~lm(height ~ mass + birth_year, data = data),
+#'     perf  = double() ~ summary(model)$adj.r.squared
+#'   )
+#'
 #' @rdname rap
 #' @export
 wap <- function(.tbl, .f) {

--- a/R/rap.R
+++ b/R/rap.R
@@ -142,7 +142,7 @@ prepare_wap <- function(.tbl, .f, check = TRUE) {
 #'             The vector validates `vec_size() == nrow(.tbl)`. This is similar
 #'             to [purrr::pmap()]
 #'
-#'   - `nap()` returns *n*othing, and can be used for side effects, similar to [purrr:::pwalk()]
+#'   - `nap()` returns *n*othing, and can be used for side effects, similar to [purrr::pwalk()]
 #'
 #'   - `rap()` adds a column to `.tbl` per formula in `...`
 #'

--- a/man/rap.Rd
+++ b/man/rap.Rd
@@ -22,33 +22,31 @@ rap(.tbl, ...)
 
 \item{...}{named formulas
 
- The *lhs* of each formula indicates the type, in the [vctrs::vec_c()] sense.
+The \emph{lhs} of each formula indicates the type, in the \code{\link[vctrs:vec_c]{vctrs::vec_c()}} sense.
+\itemize{
+\item empty or \code{list()}: no check is performed on the results of
+the rhs expressionand a list is returned.
+\item \code{data.frame()}:  to indicate that the rhs should evaluate
+to a data frame of 1 row. The data frames don't need to be of a specific types
+and are are combined with \code{\link[vctrs:vec_rbind]{vctrs::vec_rbind()}}.
+\item A data frame of a specific type, e.g. \code{data.frame(x = integer(), y = double())}
+The rhs should evaluate to a data frame of that type with 1 row.
+\item Any other ptype that makes sense for \code{\link[vctrs:vec_c]{vctrs::vec_c()}}. Each result must
+validate \code{vctrs::vec_size(.) == 1L} and are combined with
+\code{vctrs::vec_c(!!!, .ptype = .ptype)}
+}
 
- - empty or `list()`: no check is performed on the results of
- the rhs expressionand a list is returned.
-
- - `data.frame()`:  to indicate that the rhs should evaluate
- to a data frame of 1 row. The data frames don't need to be of a specific types
- and are are combined with [vctrs::vec_rbind()].
-
- - A data frame of a specific type, e.g. `data.frame(x = integer(), y = double())`
- The rhs should evaluate to a data frame of that type with 1 row.
-
- - Any other ptype that makes sense for [vctrs::vec_c()]. Each result must
- validate `vctrs::vec_size(.) == 1L` and are combined with
- `vctrs::vec_c(!!!, .ptype = .ptype)`
-
- The rhs of each formula uses columns of `.tbl`, and each stands for a single
- observation.}
+The rhs of each formula uses columns of \code{.tbl}, and each stands for a single
+observation.}
 }
 \value{
-- `wap()` returns a vector of the type specified by the lhs of the formula.
-            The vector validates `vec_size() == nrow(.tbl)`. This is similar
-            to [purrr::pmap()]
-
-  - `nap()` returns *n*othing, and can be used for side effects, similar to [purrr:::pwalk()]
-
-  - `rap()` adds a column to `.tbl` per formula in `...`
+\itemize{
+\item \code{wap()} returns a vector of the type specified by the lhs of the formula.
+The vector validates \code{vec_size() == nrow(.tbl)}. This is similar
+to \code{\link[purrr:pmap]{purrr::pmap()}}
+\item \code{nap()} returns \emph{n}othing, and can be used for side effects, similar to \code{\link[purrr:::pwalk]{purrr::::pwalk()}}
+\item \code{rap()} adds a column to \code{.tbl} per formula in \code{...}
+}
 }
 \description{
 Map over columns of a data frame simultaneously

--- a/man/rap.Rd
+++ b/man/rap.Rd
@@ -86,4 +86,13 @@ tbl \%>\%
      n = integer() ~ nrow(x)
   )
 
+# rap is especially useful for iterating
+# over multiple models
+starwars \%>\%
+  nest_by(gender) \%>\%
+  rap(
+    model = ~lm(height ~ mass + birth_year, data = data),
+    perf  = double() ~ summary(model)$adj.r.squared
+  )
+
 }

--- a/man/rap.Rd
+++ b/man/rap.Rd
@@ -44,7 +44,7 @@ observation.}
 \item \code{wap()} returns a vector of the type specified by the lhs of the formula.
 The vector validates \code{vec_size() == nrow(.tbl)}. This is similar
 to \code{\link[purrr:pmap]{purrr::pmap()}}
-\item \code{nap()} returns \emph{n}othing, and can be used for side effects, similar to \code{\link[purrr:::pwalk]{purrr::::pwalk()}}
+\item \code{nap()} returns \emph{n}othing, and can be used for side effects, similar to \code{\link[purrr:pwalk]{purrr::pwalk()}}
 \item \code{rap()} adds a column to \code{.tbl} per formula in \code{...}
 }
 }

--- a/man/zest_join.Rd
+++ b/man/zest_join.Rd
@@ -13,20 +13,22 @@ zest_join(x, y, ...)
 
 \item{...}{named predicate formulas
 
-The rhs of the formulas is used y [dplyr::filter()] on `y` for each row of `x`.
-
-  - Literal column names refer to columns of `y`. Alternatively you can use `.data$`.
-
-  - To use the current value for a column of `x` you can use unquoting, e.g. `!!cyl`}
+The rhs of the formulas is used y \code{\link[dplyr:filter]{dplyr::filter()}} on \code{y} for each row of \code{x}.
+\itemize{
+\item Literal column names refer to columns of \code{y}. Alternatively you can use \code{.data$}.
+\item To use the current value for a column of \code{x} you can use unquoting, e.g. \code{!!cyl}
+}}
 }
 \value{
-a tibble that contains all columns and rows of `x`, plus an additional list column per formula:
-  - its name is given by the name of the formula
-  - each element of the column is a tibble
-  - each of the tibbles is a subset of `y` according to the rhs of the formula
+a tibble that contains all columns and rows of \code{x}, plus an additional list column per formula:
+\itemize{
+\item its name is given by the name of the formula
+\item each element of the column is a tibble
+\item each of the tibbles is a subset of \code{y} according to the rhs of the formula
+}
 }
 \description{
-a zest join is similar to a [dplyr::nest_join()] but the rows of `y` that are
+a zest join is similar to a \code{\link[dplyr:nest_join]{dplyr::nest_join()}} but the rows of \code{y} that are
 included in the list column are controlled by a predicate.
 }
 \examples{


### PR DESCRIPTION
- adds a silly but descriptive "multiple model" example
- turns on roxygen+markdown
- fixes a documentation crosslink typo by using `::` not `:::`